### PR TITLE
feat: add set maintenance method for triggers

### DIFF
--- a/moira_client/models/trigger.py
+++ b/moira_client/models/trigger.py
@@ -356,7 +356,6 @@ class TriggerManager:
         except InvalidJSONError:
             return False
 
-
     def is_exist(self, trigger):
         """
         Check whether trigger exists or not
@@ -370,6 +369,16 @@ class TriggerManager:
                 set(trigger.tags) == set(moira_trigger.tags):
                 return True
         return False
+
+    def set_maintenance(self, trigger_id, unix_time):
+        """
+        Puts/remove a Moira trigger to/from maintenance mode
+        :param trigger_id: int ID of the Trigger to modify
+        :param unix_time int unix time representation of how long the maintenance should be set
+        :return:
+        """
+        result = self._client.put(self._full_path(trigger_id), {'trigger': unix_time})
+        return result
 
     def get_non_existent(self, triggers):
         """

--- a/moira_client/models/trigger.py
+++ b/moira_client/models/trigger.py
@@ -377,7 +377,19 @@ class TriggerManager:
         :param unix_time int unix time representation of how long the maintenance should be set
         :return:
         """
-        result = self._client.put(self._full_path(trigger_id), {'trigger': unix_time})
+        data = {
+            'trigger': unix_time
+        }
+        trigger_path = self._full_path(trigger_id+"/setMaintenance")
+        try:
+            self._client.put(trigger_path, json=data)
+            return True
+        except InvalidJSONError as e:
+            if e.content == b'':  # successfully if response is blank
+                return True
+            return False
+
+
         return result
 
     def get_non_existent(self, triggers):

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -86,3 +86,16 @@ class TriggerTest(ModelTest):
 
             self.assertTrue(get_mock.called)
             self.assertEqual(trigger_id, trigger.id)
+
+    def test_set_maintenance(self):
+        client = Client(self.api_url)
+        trigger_manager = TriggerManager(client)
+
+        trigger_id = '1'
+        duration = 1583249059
+
+        with patch.object(client, 'put', return_value={}) as put_mock:
+            res = trigger_manager.set_maintenance(trigger_id, duration)
+            self.assertTrue(put_mock.called)
+            self.assertFalse(bool(res))
+            put_mock.assert_called_with('trigger/'+trigger_id, {'trigger': 1583249059})

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -95,7 +95,10 @@ class TriggerTest(ModelTest):
         duration = 1583249059
 
         with patch.object(client, 'put', return_value={}) as put_mock:
+            data = {
+                'trigger': 1583249059
+            }
             res = trigger_manager.set_maintenance(trigger_id, duration)
             self.assertTrue(put_mock.called)
-            self.assertFalse(bool(res))
-            put_mock.assert_called_with('trigger/'+trigger_id, {'trigger': 1583249059})
+            self.assertTrue(res)
+            put_mock.assert_called_with('trigger/'+trigger_id+'/setMaintenance', json=data)


### PR DESCRIPTION
## PR Summary
Add a wrapper for the `/setMaintenance` endpoint which is responsible for turning metrics maintenance on/off.

Closes #8 